### PR TITLE
Add ability to work with multiple suite projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [3.20.2] - 2022-12-08
 
 ### Added
-- TestRail: Ability to work with multiple test suite projects 
+- TestRail: Ability to work with multiple test suite projects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[3.20.1] - 2022-10-07
+[3.20.2] - 2022-12-08
 
-### Fixed
-- Allure TestOps: Fixing a bug in a deleting algorithm.
+### Added
+- TestRail: Ability to work with multiple test suites projects 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [3.20.2] - 2022-12-08
 
 ### Added
-- TestRail: Ability to work with multiple test suites projects 
+- TestRail: Ability to work with multiple test suite projects 

--- a/GherkinSyncTool.Synchronizers.TestRail/Client/TestRailClientWrapper.cs
+++ b/GherkinSyncTool.Synchronizers.TestRail/Client/TestRailClientWrapper.cs
@@ -115,8 +115,9 @@ namespace GherkinSyncTool.Synchronizers.TestRail.Client
 
         public IEnumerable<Section> GetSections(ulong projectId)
         {
+            var suiteId = _testRailSettings.SuiteId;
             var policy = CreateResultHandlerPolicy<IList<Section>>();
-            var result = policy.Execute(() => _testRailClient.GetSections(projectId));
+            var result = policy.Execute(() => _testRailClient.GetSections(projectId, suiteId));
             ValidateRequestResult(result);
             return result.Payload;
         }

--- a/GherkinSyncTool/GherkinSyncTool.csproj
+++ b/GherkinSyncTool/GherkinSyncTool.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <AssemblyVersion>3.20.1</AssemblyVersion>
+        <AssemblyVersion>3.20.2</AssemblyVersion>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <PackAsTool>true</PackAsTool>

--- a/README.md
+++ b/README.md
@@ -55,9 +55,8 @@ GherkinSyncTool has the next ways how to run:
 
 ### TestRail
 
-1. The TestRail's project must be operating in single package mode;
-2. TestRail's API should be enabled;
-3. In order for the tool to work correctly, the TestRail test template should have the
+1. TestRail's API should be enabled;
+2. In order for the tool to work correctly, the TestRail test template should have the
 custom fields that are presented in the table below. The template should not contain any required fields. An existing
 template can be used or a new one created.
 


### PR DESCRIPTION
Issue about this: https://github.com/quantori/GherkinSyncTool/issues/61

Basically if I'm not mistaken, there was not much to do here. Everything was there already, SuiteId was just missing from the `GetSections()` method in `TestRailClientWrapper`, so I added it. Because `SuiteId ` is mandatory to have inside the config and it is already checked, if it's value is 0, I don't think there is anything else need to be done.

**Side note** - For some reason TestRail API is built so, that when we send request on `/api/v2/get_sections/{project_id}&suite_id={suite_id}` endpoint, where `project id` is the id of the 'single suite project' and `suite_id `is some random number from the ids of the suites on that account (even if it's not from the same project), it will still return 200, even if the suite_id is incorrect. I guess it's not strictly checked in this situation, because with 'single suite projects' that param is optional, it just checks if suite with that id exists on the account.