### PR TITLE
Azure DevOps: add ability to use more than 20000 work items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[3.20.3] - 2023-01-25
+[3.20.3] - 2023-02-28
 
 ### Added
 - Azure DevOps: Ability to work with more, than 20000 work items

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[3.20.2] - 2022-12-08
+[3.20.3] - 2023-01-25
 
 ### Added
-- TestRail: Ability to work with multiple test suite projects.
+- Azure DevOps: Ability to work with more, than 20000 work items

--- a/GherkinSyncTool.Synchronizers.AzureDevOps/Client/AzureDevopsClient.cs
+++ b/GherkinSyncTool.Synchronizers.AzureDevOps/Client/AzureDevopsClient.cs
@@ -196,7 +196,7 @@ namespace GherkinSyncTool.Synchronizers.AzureDevOps.Client
             return workItemTrackingHttpClient;
         }
 
-        private IEnumerable<WorkItemReference> GetListOfWorkItemsWithQuery(string query)
+        private IList<WorkItemReference> GetListOfWorkItemsWithQuery(string query)
         {
             var results = new List<WorkItemReference>();
             var workItemTrackingHttpClient = GetWorkItemTrackingHttpClient();
@@ -216,13 +216,13 @@ namespace GherkinSyncTool.Synchronizers.AzureDevOps.Client
                 var currentResults = workItemTrackingHttpClient.QueryByWiqlAsync(wiql, _azureDevopsSettings.Project)
                     .Result.WorkItems.ToList();
                 
-                if (currentResults.Count == 0)
+                if (!currentResults.Any())
                 {
                     try
                     {
                         results.AddRange(workItemTrackingHttpClient.QueryByWiqlAsync(new Wiql
                         {
-                            Query = $@"{query} AND {WorkItemFields.Id} >= {counter}"
+                            Query = $@"{query} AND [{WorkItemFields.Id}] >= {counter}"
                         }).Result.WorkItems.ToList());
                         
                         moreResults = false;

--- a/GherkinSyncTool/GherkinSyncTool.csproj
+++ b/GherkinSyncTool/GherkinSyncTool.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <AssemblyVersion>3.20.2</AssemblyVersion>
+        <AssemblyVersion>3.20.3</AssemblyVersion>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
In Azure DevOps, When having more than 20000 work items, GherkinSyncTool was failing with the `VS402337` exception. 

Because it's not a GherkinSyncTool bug, but it's just a limitation from the VSTS side, I think it's more of a feature, than a fix. So I marked it in the `CHANGELOG.md` with `Added` tag instead of `Fixed`.